### PR TITLE
Add link to twitter feed for #nodeschoolday

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <div class="container">
       <br>
       <div class="row center">
-        <h5 class="header col s12 light">Over 24 hours, the <a href="http://nodeschool.io/" class="black-text">NodeSchool</a> community will come together and organize NodeSchool events all around the globe. #nodeschoolday</h5>
+        <h5 class="header col s12 light">Over 24 hours, the <a href="http://nodeschool.io/" class="black-text">NodeSchool</a> community will come together and organize NodeSchool events all around the globe. <a href="https://twitter.com/search?q=%23nodeschoolday" target="_blank">#nodeschoolday</a></h5>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adding a link to the twitter feed for #nodeschoolday with target="_blank". https://twitter.com/search?q=%23nodeschoolday

Issue fixed: https://github.com/nodeschool/international-day/issues/141
